### PR TITLE
Relative path fix

### DIFF
--- a/tasks/assets_inline.js
+++ b/tasks/assets_inline.js
@@ -134,7 +134,7 @@ module.exports = function(grunt) {
         }
 
         if(url.parse(style).protocol) { return; }
-        var filePath = (style.substr(0,1) === "/") ? path.resolve(options.cssDir, style.substr(1)) : path.join(path.dirname(filePair.src), style);
+        var filePath = (style.substr(0,1) === "/") ? path.resolve(options.cssDir, style.substr(1)) : path.join(path.dirname(filePair.src.toString()), style);
         grunt.log.writeln(('    css: ').cyan + filePath);
         $(this).replaceWith(options.cssTags.start + grunt.file.read(filePath) + options.cssTags.end);
 
@@ -157,7 +157,7 @@ module.exports = function(grunt) {
           delete attributes.src;
         }
 
-        var filePath = (script.substr(0,1) === "/") ? path.resolve(options.jsDir, script.substr(1)) : path.join(path.dirname(filePair.src), script);
+        var filePath = (script.substr(0,1) === "/") ? path.resolve(options.jsDir, script.substr(1)) : path.join(path.dirname(filePair.src.toString()), script);
         grunt.log.writeln(('     js: ').cyan + filePath);
 
         //create and replace script with new scipt tag


### PR DESCRIPTION
When a relative path is encountered, filePair.src is now stringified for
use, resolving a grunt error (expected string, received array).
