### PR TITLE
Fix error on firstChild is a Node.COMMENT_NODE

### DIFF
--- a/tasks/assets_inline.js
+++ b/tasks/assets_inline.js
@@ -393,7 +393,7 @@ module.exports = function(grunt) {
       if (options.serialize) {
         var html = dom.serialize();
       } else {
-        var html = dom.window.document.firstChild.outerHTML.replace(/<(\/?)(html|head|body)>/gm, '');
+        var html = dom.window.document.children[0].outerHTML.replace(/<(\/?)(html|head|body)>/gm, '');
       }
 
       grunt.file.write(path.resolve(filePair.dest), html);


### PR DESCRIPTION
Error "Cannot read property 'replace' of undefined" is given if first element of html template is Node.COMMENT_NODE

Reproduce: 
 * use option "serialize: false" 
 * HTML Template file must contain comment node e.g. `<!-- foo -->` as a first node