### PR TITLE
Fix error on fragment with first node as Node.COMMENT_NODE

### DIFF
--- a/tasks/assets_inline.js
+++ b/tasks/assets_inline.js
@@ -393,7 +393,7 @@ module.exports = function(grunt) {
       if (options.serialize) {
         var html = dom.serialize();
       } else {
-        var html = dom.window.document.firstChild.outerHTML.replace(/<(\/?)(html|head|body)>/gm, '');
+        var html = dom.window.document.children[0].outerHTML.replace(/<(\/?)(html|head|body)>/gm, '');
       }
 
       grunt.file.write(path.resolve(filePair.dest), html);

--- a/test/fixtures/index-fragment.html
+++ b/test/fixtures/index-fragment.html
@@ -1,3 +1,4 @@
+<!-- comment to ignore -->
 <link rel="icon" href="favicon/favicon.png" type="image/png">
 <link rel="icon" href="favicon/favicon.svg" sizes="any" type="image/svg+xml">
 <link rel="mask-icon" href="favicon/mask-icon.svg" color="#000">


### PR DESCRIPTION
Error "Cannot read property 'replace' of undefined" is given if first element of html template is Node.COMMENT_NODE

Reproduce:
 * use option "serialize: false"
 * HTML Template file mist contain comment node e.g. <!-- foo --> as a first node